### PR TITLE
Add configs for MiroThinker v0.1 SFT

### DIFF
--- a/recipes/configs/mirothinker_v0_1/sft/mirothinker_v0_1_14B_qwen3_40k_bs128_pack.yaml
+++ b/recipes/configs/mirothinker_v0_1/sft/mirothinker_v0_1_14B_qwen3_40k_bs128_pack.yaml
@@ -1,0 +1,118 @@
+output_dir: ./output/mirothinker_v0_1_14B_qwen3_40k_bs128_pack
+
+use_flash_attention: True  # suggest to use flash attention to avoid OOM and speed up training
+
+# Parallelism
+ulysses_sequence_parallel_size: 1
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Tokenizer
+tokenizer:
+  _component_: mirotrain.models.qwen3.qwen3_tokenizer_auto
+  path: ./models/Qwen3-14B
+  max_seq_len: 40960
+
+# Dataset
+dataset:
+  _component_: miromind.datasets.odr_chat_dataset
+  source: "miromind-ai/MiroVerse-v0.1"
+  name: "MiroVerse-v0.1-all"
+  split: "train"
+  data_files: null
+  conversation_column: "messages"
+  conversation_style: "traces"
+  masking_strategy: "train_on_assistant" # should be one of train_on_assistant, train_on_all, train_on_last
+  streaming_pack: True
+  packed_seq_len: 40960
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: mirotrain.models.qwen3.qwen3_14b_instruct
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-14B
+  checkpoint_files: [
+    model-00001-of-00008.safetensors,
+    model-00002-of-00008.safetensors,
+    model-00003-of-00008.safetensors,
+    model-00004-of-00008.safetensors,
+    model-00005-of-00008.safetensors,
+    model-00006-of-00008.safetensors,
+    model-00007-of-00008.safetensors,
+    model-00008-of-00008.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+resume_from_checkpoint: False
+
+## Fine-tuning arguments
+batch_size: 1
+epochs: 3
+gradient_accumulation_steps: 1  # Use to increase effective batch size
+
+loss:
+  _component_: mirotrain.modules.loss.LigerLinearCrossEntropyLoss
+
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.1
+  lr: 4e-5
+
+clip_grad_norm: 1.0
+
+lr_scheduler:
+  _component_: mirotrain.training.get_cosine_schedule_with_warmup
+  warmup_ratio: 0.1
+  num_cycles: 0.5
+
+max_steps_per_epoch: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+optimizer_in_bwd: False  # True saves memory. Requires gradient_accumulation_steps=1
+
+# Training env
+device: cuda
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/mirothinker_v0_1/sft/mirothinker_v0_1_32B_qwen3_40k_bs128_pack.yaml
+++ b/recipes/configs/mirothinker_v0_1/sft/mirothinker_v0_1_32B_qwen3_40k_bs128_pack.yaml
@@ -1,0 +1,127 @@
+output_dir: ./output/mirothinker_v0_1_32B_qwen3_40k_bs128_pack
+
+use_flash_attention: True  # suggest to use flash attention to avoid OOM and speed up training
+
+# Parallelism
+ulysses_sequence_parallel_size: 1
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Tokenizer
+tokenizer:
+  _component_: mirotrain.models.qwen3.qwen3_tokenizer_auto
+  path: ./models/Qwen3-32B
+  max_seq_len: 40960
+
+# Dataset
+dataset:
+  _component_: miromind.datasets.odr_chat_dataset
+  source: "miromind-ai/MiroVerse-v0.1"
+  name: "MiroVerse-v0.1-all"
+  split: "train"
+  data_files: null
+  conversation_column: "messages"
+  conversation_style: "traces"
+  masking_strategy: "train_on_assistant" # should be one of train_on_assistant, train_on_all, train_on_last
+  streaming_pack: True
+  packed_seq_len: 40960
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: mirotrain.models.qwen3.qwen3_32b
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-32B
+  checkpoint_files: [
+    model-00001-of-00017.safetensors,
+    model-00002-of-00017.safetensors,
+    model-00003-of-00017.safetensors,
+    model-00004-of-00017.safetensors,
+    model-00005-of-00017.safetensors,
+    model-00006-of-00017.safetensors,
+    model-00007-of-00017.safetensors,
+    model-00008-of-00017.safetensors,
+    model-00009-of-00017.safetensors,
+    model-00010-of-00017.safetensors,
+    model-00011-of-00017.safetensors,
+    model-00012-of-00017.safetensors,
+    model-00013-of-00017.safetensors,
+    model-00014-of-00017.safetensors,
+    model-00015-of-00017.safetensors,
+    model-00016-of-00017.safetensors,
+    model-00017-of-00017.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+resume_from_checkpoint: False
+
+## Fine-tuning arguments
+batch_size: 1
+epochs: 3
+gradient_accumulation_steps: 1  # Use to increase effective batch size
+
+loss:
+  _component_: mirotrain.modules.loss.LigerLinearCrossEntropyLoss
+
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.1
+  lr: 4e-5
+
+clip_grad_norm: 1.0
+
+lr_scheduler:
+  _component_: mirotrain.training.get_cosine_schedule_with_warmup
+  warmup_ratio: 0.1
+  num_cycles: 0.5
+
+max_steps_per_epoch: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+optimizer_in_bwd: False  # True saves memory. Requires gradient_accumulation_steps=1
+
+# Training env
+device: cuda
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/mirothinker_v0_1/sft/mirothinker_v0_1_8B_qwen3_40k_bs128_pack.yaml
+++ b/recipes/configs/mirothinker_v0_1/sft/mirothinker_v0_1_8B_qwen3_40k_bs128_pack.yaml
@@ -1,0 +1,115 @@
+output_dir: ./output/mirothinker_v0_1_8B_qwen3_40k_bs128_pack
+
+use_flash_attention: True  # suggest to use flash attention to avoid OOM and speed up training
+
+# Parallelism
+ulysses_sequence_parallel_size: 1
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Tokenizer
+tokenizer:
+  _component_: mirotrain.models.qwen3.qwen3_tokenizer_auto
+  path: ./models/Qwen3-8B
+  max_seq_len: 40960
+
+# Dataset
+dataset:
+  _component_: miromind.datasets.odr_chat_dataset
+  source: "miromind-ai/MiroVerse-v0.1"
+  name: "MiroVerse-v0.1-all"
+  split: "train"
+  data_files: null
+  conversation_column: "messages"
+  conversation_style: "traces"
+  masking_strategy: "train_on_assistant" # should be one of train_on_assistant, train_on_all, train_on_last
+  streaming_pack: True
+  packed_seq_len: 40960
+seed: null
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: mirotrain.models.qwen3.qwen3_8b_instruct
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-8B
+  checkpoint_files: [
+    model-00001-of-00005.safetensors,
+    model-00002-of-00005.safetensors,
+    model-00003-of-00005.safetensors,
+    model-00004-of-00005.safetensors,
+    model-00005-of-00005.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+resume_from_checkpoint: False
+
+## Fine-tuning arguments
+batch_size: 1
+epochs: 4
+gradient_accumulation_steps: 1  # Use to increase effective batch size
+
+loss:
+  _component_: mirotrain.modules.loss.LigerLinearCrossEntropyLoss
+
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.1
+  lr: 4e-5
+
+clip_grad_norm: 1.0
+
+lr_scheduler:
+  _component_: mirotrain.training.get_cosine_schedule_with_warmup
+  warmup_ratio: 0.1
+  num_cycles: 0.5
+
+max_steps_per_epoch: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+optimizer_in_bwd: False  # True saves memory. Requires gradient_accumulation_steps=1
+
+# Training env
+device: cuda
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1


### PR DESCRIPTION
In this PR, I added the configs for reproducing the MiroThinker v0.1 SFT model training.

These configs cover three different sizes of MiroThinker models. The training data used is the `MiroVerse-v0.1-all` subset from [MiroVerse-v0.1](https://huggingface.co/datasets/miromind-ai/MiroVerse-v0.1), with the split set to `train`.

| Hyperparameter | MiroThinker-8B-SFT-v0.1  | MiroThinker-14B-SFT-v0.1 | MiroThinker-32B-SFT-v0.1 |
| -------------- | -------- | --------- | --------- |
| Epochs         | 4        | 3         | 3         |
| Learning Rate  | 4e-5     | 4e-5      | 4e-5      |
| Weight Decay   | 0.1      | 0.1       | 0.1       |
| Packed Data    | Enabled  | Enabled   | Enabled   |
| Context Length | 40k      | 40k       | 40k       |
| Batch Size     | 128      | 128       | 128       |
| Clip Grad Norm | 1.0      | 1.0       | 1.0       |
| Warmup Ratio   | 0.1      | 0.1       | 0.1       |
