### PR TITLE
Add configs for MiroThinker v0.1 DPO

### DIFF
--- a/recipes/configs/mirothinker_v0_1/dpo/mirothinker_v0_1_14B_qwen3_40k_bs32.yaml
+++ b/recipes/configs/mirothinker_v0_1/dpo/mirothinker_v0_1_14B_qwen3_40k_bs32.yaml
@@ -1,0 +1,135 @@
+output_dir: ./output/mirothinker_v0_1_14B_qwen3_40k_bs32_dpo
+
+# Parallelism
+ulysses_sequence_parallel_size: 1
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Tokenizer
+tokenizer:
+  _component_: mirotrain.models.qwen3.qwen3_tokenizer_auto
+  path: ./models/Qwen3-14B
+  max_seq_len: 40960
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.preference_dataset
+  source: "miromind-ai/MiroVerse-v0.1"
+  name: "MiroVerse-DPO"
+  split: "MuSiQue_14B_DPO"
+seed: 1024
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: mirotrain.models.qwen3.qwen3_14b_instruct
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-14B
+  checkpoint_files: [
+    model-00001-of-00008.safetensors,
+    model-00002-of-00008.safetensors,
+    model-00003-of-00008.safetensors,
+    model-00004-of-00008.safetensors,
+    model-00005-of-00008.safetensors,
+    model-00006-of-00008.safetensors,
+    model-00007-of-00008.safetensors,
+    model-00008-of-00008.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+resume_from_checkpoint: False
+
+
+# The ref_checkpointer should always point to the original weights.
+ref_checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-14B
+  checkpoint_files: [
+    model-00001-of-00008.safetensors,
+    model-00002-of-00008.safetensors,
+    model-00003-of-00008.safetensors,
+    model-00004-of-00008.safetensors,
+    model-00005-of-00008.safetensors,
+    model-00006-of-00008.safetensors,
+    model-00007-of-00008.safetensors,
+    model-00008-of-00008.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+
+
+## Fine-tuning arguments
+batch_size: 1
+epochs: 3
+## If using single-node, need to set gradient_accumulation_steps 
+## to 4 to increase the effective batch size to 32
+gradient_accumulation_steps: 4
+
+# loss:
+loss:
+  _component_: mirotrain.modules.loss.DPOLoss
+  beta: 0.1
+  loss_config: {"sigmoid": 1.0}
+  # loss_config: {"sigmoid": 1.0, "sft": 0.1}
+
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.05
+  lr: 1e-5
+
+lr_scheduler:
+  _component_: mirotrain.training.get_cosine_schedule_with_warmup
+  warmup_ratio: 0.1
+  num_cycles: 0.5
+
+
+max_steps_per_epoch: null
+clip_grad_norm: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+optimizer_in_bwd: False  # True saves memory. Requires gradient_accumulation_steps=1
+
+# Training env
+device: cuda
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/mirothinker_v0_1/dpo/mirothinker_v0_1_32B_qwen3_40k_bs32.yaml
+++ b/recipes/configs/mirothinker_v0_1/dpo/mirothinker_v0_1_32B_qwen3_40k_bs32.yaml
@@ -1,0 +1,153 @@
+output_dir: ./output/mirothinker_v0_1_32B_qwen3_40k_bs32_dpo
+
+# Parallelism
+ulysses_sequence_parallel_size: 1
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Tokenizer
+tokenizer:
+  _component_: mirotrain.models.qwen3.qwen3_tokenizer_auto
+  path: ./models/Qwen3-32B
+  max_seq_len: 40960 # if you use only 1 node for training, you can reduce this to around 22k
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.preference_dataset
+  source: "miromind-ai/MiroVerse-v0.1"
+  name: "MiroVerse-DPO"
+  split: "MuSiQue_32B_DPO"
+seed: 1024
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: mirotrain.models.qwen3.qwen3_32b
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-32B
+  checkpoint_files: [
+    model-00001-of-00017.safetensors,
+    model-00002-of-00017.safetensors,
+    model-00003-of-00017.safetensors,
+    model-00004-of-00017.safetensors,
+    model-00005-of-00017.safetensors,
+    model-00006-of-00017.safetensors,
+    model-00007-of-00017.safetensors,
+    model-00008-of-00017.safetensors,
+    model-00009-of-00017.safetensors,
+    model-00010-of-00017.safetensors,
+    model-00011-of-00017.safetensors,
+    model-00012-of-00017.safetensors,
+    model-00013-of-00017.safetensors,
+    model-00014-of-00017.safetensors,
+    model-00015-of-00017.safetensors,
+    model-00016-of-00017.safetensors,
+    model-00017-of-00017.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+resume_from_checkpoint: False
+
+
+# The ref_checkpointer should always point to the original weights.
+ref_checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-32B
+  checkpoint_files: [
+    model-00001-of-00017.safetensors,
+    model-00002-of-00017.safetensors,
+    model-00003-of-00017.safetensors,
+    model-00004-of-00017.safetensors,
+    model-00005-of-00017.safetensors,
+    model-00006-of-00017.safetensors,
+    model-00007-of-00017.safetensors,
+    model-00008-of-00017.safetensors,
+    model-00009-of-00017.safetensors,
+    model-00010-of-00017.safetensors,
+    model-00011-of-00017.safetensors,
+    model-00012-of-00017.safetensors,
+    model-00013-of-00017.safetensors,
+    model-00014-of-00017.safetensors,
+    model-00015-of-00017.safetensors,
+    model-00016-of-00017.safetensors,
+    model-00017-of-00017.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+
+
+## Fine-tuning arguments
+batch_size: 1
+epochs: 3
+## If using single-node, need to set gradient_accumulation_steps 
+## to 4 to increase the effective batch size to 32
+gradient_accumulation_steps: 4
+
+# loss:
+loss:
+  _component_: mirotrain.modules.loss.DPOLoss
+  beta: 0.1
+  loss_config: {"sigmoid": 1.0}
+  # loss_config: {"sigmoid": 1.0, "sft": 0.1}
+
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.05
+  lr: 1e-5
+
+lr_scheduler:
+  _component_: mirotrain.training.get_cosine_schedule_with_warmup
+  warmup_ratio: 0.1
+  num_cycles: 0.5
+
+
+max_steps_per_epoch: null
+clip_grad_norm: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+optimizer_in_bwd: False  # True saves memory. Requires gradient_accumulation_steps=1
+
+# Training env
+device: cuda
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/mirothinker_v0_1/dpo/mirothinker_v0_1_8B_qwen3_40k_bs32.yaml
+++ b/recipes/configs/mirothinker_v0_1/dpo/mirothinker_v0_1_8B_qwen3_40k_bs32.yaml
@@ -1,0 +1,129 @@
+output_dir: ./output/mirothinker_v0_1_8B_qwen3_40k_bs32_dpo
+
+# Parallelism
+ulysses_sequence_parallel_size: 1
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+# Tokenizer
+tokenizer:
+  _component_: mirotrain.models.qwen3.qwen3_tokenizer_auto
+  path: ./models/Qwen3-8B
+  max_seq_len: 40960 
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.preference_dataset
+  source: "miromind-ai/MiroVerse-v0.1"
+  name: "MiroVerse-DPO"
+  split: "MuSiQue_8B_DPO"
+seed: 1024
+shuffle: True
+
+# Model Arguments
+model:
+  _component_: mirotrain.models.qwen3.qwen3_8b_instruct
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-8B
+  checkpoint_files: [
+    model-00001-of-00005.safetensors,
+    model-00002-of-00005.safetensors,
+    model-00003-of-00005.safetensors,
+    model-00004-of-00005.safetensors,
+    model-00005-of-00005.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+resume_from_checkpoint: False
+
+
+# The ref_checkpointer should always point to the original weights.
+ref_checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: ./models/Qwen3-8B
+  checkpoint_files: [
+    model-00001-of-00005.safetensors,
+    model-00002-of-00005.safetensors,
+    model-00003-of-00005.safetensors,
+    model-00004-of-00005.safetensors,
+    model-00005-of-00005.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN3
+
+
+## Fine-tuning arguments
+batch_size: 1
+epochs: 3
+## If using single-node, need to set gradient_accumulation_steps 
+## to 4 to increase the effective batch size to 32
+gradient_accumulation_steps: 4
+
+# loss:
+loss:
+  _component_: mirotrain.modules.loss.DPOLoss
+  beta: 0.1
+  loss_config: {"sigmoid": 1.0}
+  # loss_config: {"sigmoid": 1.0, "sft": 0.1}
+
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.05
+  lr: 1e-5
+
+lr_scheduler:
+  _component_: mirotrain.training.get_cosine_schedule_with_warmup
+  warmup_ratio: 0.1
+  num_cycles: 0.5
+
+
+max_steps_per_epoch: null
+clip_grad_norm: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+optimizer_in_bwd: False  # True saves memory. Requires gradient_accumulation_steps=1
+
+# Training env
+device: cuda
+
+# Reduced precision
+dtype: bf16
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: False
+log_level: INFO  # DEBUG, WARN, etc.
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1


### PR DESCRIPTION
In this PR, I added the configs for reproducing the MiroThinker v0.1 DPO model training.

These configs cover three different sizes of MiroThinker models. The training data used is the corresponding split in `MiroVerse-DPO` subset from [MiroVerse-v0.1](https://huggingface.co/datasets/miromind-ai/MiroVerse-v0.1).

We use a unified hyper-parameter setting for 8B / 14B / 32B models. 
| Hyperparameter | MiroThinker-DPO-v0.1  | 
| -------------- | -------- | 
| Epochs         | 3        | 
| Learning Rate  | 1e-5     | 
| Weight Decay   | 0.05     | 
| Context Length | 40k      | 
| Batch Size     | 32      | 
| Warmup Ratio   | 0.1      | 
| Beta | 0.1 |
